### PR TITLE
Uses safer way to remove old content.

### DIFF
--- a/src/deployer.js
+++ b/src/deployer.js
@@ -5,6 +5,7 @@ const path = require('path');
 const request = require('request');
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
+
 const exec = require('child_process').exec;
 
 const publicDir = process.env.GITLAB_CE_PAGES_PUBLIC_DIR;
@@ -14,28 +15,19 @@ const projectRoot = process.env.PROJECT_ROOT;
 let gitlabUrl = process.env.GITLAB_URL || 'localhost';
 gitlabUrl = gitlabUrl.replace(/\/*$/, '/');
 
-function extract(artifactName, artifactPath, destination) {
-  exec('unzip ' + artifactPath + ' -d ' + destination, (err, stdout, stderr) => {
+function extract(artifactName, artifactPath, tempdestination, destination) {
+  exec('unzip ' + artifactPath + ' -d ' + tempdestination, (err, stdout, stderr) => {
     if (err) {
       console.error('unzip', artifactName, 'failed');
       console.error(err);
+      rimraf(tempdestination, () => {
+        console.log('tempdestination', tempdestination, 'removed');
+      });
     } else {
-      console.log('unzipped', artifactName, 'into', destination);
-      console.log('removing artifact', artifactPath);
-      // Artifact is expected to run parallel with moving files down below
-      exec('rm ' + artifactPath,
-        (err, stdout, stderr) => {
-          if (err) {
-            console.error('artifact removal', artifactPath, 'failed');
-            console.error(err);
-          } else {
-            console.log('artifact removal', artifactPath, 'succeed');
-          }
-        }
-      );
+      console.log('unzipped', artifactName, 'into', tempdestination);
       if (projectRoot) {
         console.log('moving files out of', projectRoot);
-        exec('cd ' + destination + ' && mv ' + projectRoot + ' PROJECT_ROOT && cd PROJECT_ROOT && mv ./* .. && cd .. && rm -rf PROJECT_ROOT',
+        exec('cd ' + tempdestination + ' && mv ' + projectRoot + ' PROJECT_ROOT && cd PROJECT_ROOT && mv ./* .. && cd .. && rm -rf PROJECT_ROOT',
           (err, stdout, stderr) => {
             if (err) {
               console.error('files moving out of', projectRoot, 'failed');
@@ -46,7 +38,29 @@ function extract(artifactName, artifactPath, destination) {
           }
         );
       }
+      rimraf(destination, () => {
+        exec('mv ' + tempdestination + ' ' + destination,
+          (err, stdout, stderr) => {
+            if (err) {
+              console.error('Moving tempdestination', tempdestination, 'failed');
+              console.error(err);
+            }
+          }
+        );
+      });
     }
+    console.log('removing artifact', artifactPath);
+    // Artifact is expected to run parallel with moving files down below
+    exec('rm ' + artifactPath,
+      (err, stdout, stderr) => {
+        if (err) {
+          console.error('artifact removal', artifactPath, 'failed');
+          console.error(err);
+        } else {
+          console.log('artifact removal', artifactPath, 'succeed');
+        }
+      }
+    );
   });
 }
 
@@ -78,7 +92,10 @@ function update(body, pageDir) {
         return;
       }
       console.log(artifactName, 'downloaded');
-      extract(artifactName, artifactPath, pageDir);
+      const tempPageDir = pageDir + "."  + bid;
+      mkdirp(tempPageDir, (err) => {
+        extract(artifactName, artifactPath, tempPageDir, pageDir);
+      });
     });
     request
       .get(options, (error, response, body) => {
@@ -96,14 +113,6 @@ module.exports = {
     const homepageSplit = homepage.split('/');
     const pnameSplit = homepageSplit.splice(homepageSplit.length - 2, 2);
     const pageDir = path.join(publicDir, ...pnameSplit);
-    fs.stat(pageDir, (err, stats) => {
-      if (err) {
-        update(body, pageDir);
-      } else {
-        rimraf(pageDir, () => {
-          update(body, pageDir);
-        })
-      }
-    });
+    update(body, pageDir);
   }
 };

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-ce-pages",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Unofficial GitLab Pages for GitLab CE",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
- Uses a temp destination and a move on success.
- Doesn't delete the original files till a successful extract.

Without these changes it's possible to delete sites and crash the docker instance with a specially crafted POST requests. For example:

This one would remove all content from the site user/site

```
{
  'build_name': 'pages',
  'build_status': 'success',
  'repository': { 'homepage': 'https://gitlab/user/site'}
}
```

This one deletes stuff that causes the docker instance to crash and require a rebuild

```
{
  'build_name': 'pages',
  'build_status': 'success',
  'repository': { 'homepage': 'https://gitlab/user/../..'},
  'build_id': 'anything'
}
```
