### PR TITLE
added initial support for dynamic dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**1.2.3**
+- prevent dns loops
+
 **1.2.2**
 - add tini (https://github.com/krallin/tini) init system
 - deployeritself kicks of helper script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+**1.2.2**
+- add tini (https://github.com/krallin/tini) init system
+- deployeritself kicks of helper script
+- get rid of zombies caused by nodemon
+
 **1.2.1**
 - solve child process’ stdout buffer overflow problem #8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN npm install
 
 RUN apt-get install --no-install-recommends -y dnsmasq-base \
     && mkdir -p /etc/dnsmasq.d
+COPY config/dnsmasq.conf /etc/dnsmasq.d/dnsmasq.conf
 
 ENV TINI_VERSION v0.10.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,19 @@ WORKDIR ${GITLAB_CE_PAGES_WEBHOOK_DIR}
 
 COPY src/package.json ${GITLAB_CE_PAGES_WEBHOOK_DIR}/
 RUN npm install
-RUN npm install -g nodemon
 
 RUN apt-get install --no-install-recommends -y dnsmasq-base \
     && mkdir -p /etc/dnsmasq.d
 
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 COPY entrypoint.sh /
 COPY config/nginx.conf /etc/nginx/nginx.conf
 RUN rm -f /etc/nginx/conf.d/*
+RUN chown -R nginx: /var/log/nginx
 
 COPY src/ ${GITLAB_CE_PAGES_WEBHOOK_DIR}/
 
@@ -36,5 +41,4 @@ EXPOSE 53/udp
 
 VOLUME ["${GITLAB_CE_PAGES_PUBLIC_DIR}"]
 VOLUME ["${GITLAB_CE_PAGES_CNAME_DIR}"]
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/usr/bin/npm", "start"]
+CMD ["/entrypoint.sh", "/usr/bin/npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY src/package.json ${GITLAB_CE_PAGES_WEBHOOK_DIR}/
 RUN npm install
 RUN npm install -g nodemon
 
+RUN apt-get install --no-install-recommends -y dnsmasq-base \
+    && mkdir -p /etc/dnsmasq.d
+
 COPY entrypoint.sh /
 COPY config/nginx.conf /etc/nginx/nginx.conf
 RUN rm -f /etc/nginx/conf.d/*
@@ -29,6 +32,7 @@ RUN rm -f /etc/nginx/conf.d/*
 COPY src/ ${GITLAB_CE_PAGES_WEBHOOK_DIR}/
 
 EXPOSE 80/tcp
+EXPOSE 53/udp
 
 VOLUME ["${GITLAB_CE_PAGES_PUBLIC_DIR}"]
 VOLUME ["${GITLAB_CE_PAGES_CNAME_DIR}"]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It will take care of all domain names set in ```/srv/gitlab-ce-pages/cname/cname
  workspace_1/project_1 project1.gitlab.io
 ```
 
-You need to run your container in privileged mode (dnsmasq wants to drop priviliges after startup), expose udp port 53 and add another environment variable called ```PUBLIC_IP```, which is the ip address of your docker host:
+You need to run your container with ```--cap-add=NET_ADMIN``` for dnsmasq, expose udp port 53 and add another environment variable called ```PUBLIC_IP```, which is the ip address of your docker host:
 
  ```
   docker run --name gitlab-ce-pages -d --restart=always \
@@ -104,7 +104,7 @@ You need to run your container in privileged mode (dnsmasq wants to drop privili
       --env 'PUBLIC_IP=x.x.x.x' \
       --volume /srv/gitlab-ce-pages/public:/home/pages/public/ \
       --volume /srv/gitlab-ce-pages/cname:/home/pages/cname/ \
-      --privileged \
+      --cap-add=NET_ADMIN \
       -p 80:80 \
       -p 53:53/udp
       yums/gitlab-ce-pages:1.2.2

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The only ~~supported~~ encouraged way to run **GCP** is with [Docker](https://ww
  * Get Docker image
 
  ```
-  docker pull yums/gitlab-ce-pages:1.2.2
+  docker pull yums/gitlab-ce-pages:1.2.3
  ```
  
  * Run Docker container with
@@ -41,7 +41,7 @@ The only ~~supported~~ encouraged way to run **GCP** is with [Docker](https://ww
       --env 'PROJECT_ROOT=public' \
       --volume /srv/gitlab-ce-pages/public:/home/pages/public/ \
       -p 80:80 \
-      yums/gitlab-ce-pages:1.2.2
+      yums/gitlab-ce-pages:1.2.3
  ```
  
  * Tell your GitLab users the URL of your **GCP** server. They will use it as **webhook URL**. Note that this URL is the one which can actually access your running Docker instance's exposed port.
@@ -55,7 +55,7 @@ The only ~~supported~~ encouraged way to run **GCP** is with [Docker](https://ww
 
 #### DNS configuration
 
-Changed in **1.2.2**! No need to manually edit text files.
+Changed in **1.2.3**! No need to manually edit text files.
 
 You can provide a generic internal domain for pages (even provide a fake internal ```gitlab.io```) for all subdomains. Just let your existing DNS server forward all requests for ```gitlab.io``` to your **GCP** server and it will resolve to ```PUBLIC_IP``` for all local pages and further forward all unknown pages to upstream DNS servers (:exclamation: Do not build loops by again forwarding to the server which was asking **GCP**).
 
@@ -73,7 +73,7 @@ You need to run your container with ```--cap-add=NET_ADMIN``` for dnsmasq, expos
       --cap-add=NET_ADMIN \
       -p 80:80 \
       -p 53:53/udp
-      yums/gitlab-ce-pages:1.2.2
+      yums/gitlab-ce-pages:1.2.3
  ```
 
 ## Upgrading
@@ -82,7 +82,7 @@ You can easily upgrade your GCP in following steps:
  * pull latest image
 
  ```
-  docker pull yums/gitlab-ce-pages:1.2.2
+  docker pull yums/gitlab-ce-pages:1.2.3
  ```
  
  * remove running image
@@ -100,7 +100,7 @@ You can easily upgrade your GCP in following steps:
       --env 'PROJECT_ROOT=public' \
       --volume /srv/gitlab-ce-pages/public:/home/pages/public/ \
       -p 80:80 \
-      yums/gitlab-ce-pages:1.2.2
+      yums/gitlab-ce-pages:1.2.3
  ```
 
 ## Environment variables
@@ -117,7 +117,7 @@ This is a sample `docker-compose.yml` file for you if you want to use docker-com
 
     gitlab-ce-pages:
       restart: always
-      image: yums/gitlab-ce-pages:1.2.2
+      image: yums/gitlab-ce-pages:1.2.3
       environment:
         - PAGE_PRIVATE_TOKEN=private_token_of_peeking_account
         - GITLAB_URL=http://gitlab.example.com/

--- a/config/dnsmasq.conf
+++ b/config/dnsmasq.conf
@@ -1,0 +1,3 @@
+server=8.8.8.8
+server=8.8.4.4
+dns-loop-detect

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,5 @@
 touch $GITLAB_CE_PAGES_CNAME_DIR/cname.txt
 nodemon -L --exec 'bash $GITLAB_CE_PAGES_WEBHOOK_DIR/helper/generate_sites.sh' --watch $GITLAB_CE_PAGES_CNAME_DIR/cname.txt &
 /usr/sbin/nginx
+[ ! -z $PUBLIC_IP ] && /usr/sbin/dnsmasq -x /var/run/dnsmasq/dnsmasq.pid -u dnsmasq -7 /etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 /bin/sed -i "s/<relative_url>/${RELATIVE_URL}/" /etc/nginx/nginx.conf
-touch $GITLAB_CE_PAGES_CNAME_DIR/cname.txt
-nodemon -L --exec 'bash $GITLAB_CE_PAGES_WEBHOOK_DIR/helper/generate_sites.sh' --watch $GITLAB_CE_PAGES_CNAME_DIR/cname.txt &
 /usr/sbin/nginx
 [ ! -z $PUBLIC_IP ] && /usr/sbin/dnsmasq -x /var/run/dnsmasq/dnsmasq.pid -u dnsmasq -7 /etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
 exec "$@"

--- a/src/deployer.js
+++ b/src/deployer.js
@@ -16,7 +16,7 @@ const projectRoot = process.env.PROJECT_ROOT;
 let gitlabUrl = process.env.GITLAB_URL || 'localhost';
 gitlabUrl = gitlabUrl.replace(/\/*$/, '/');
 
-function extract(artifactName, artifactPath, tempDestination, destination) {
+function extract(artifactName, artifactPath, tempDestination, destination, body) {
   exec(`unzip ${artifactPath} -d ${tempDestination} >> /dev/null`, (err, stdout, stderr) => {
     if (err) {
       console.error('unzip', artifactName, 'failed');
@@ -54,6 +54,20 @@ function extract(artifactName, artifactPath, tempDestination, destination) {
                       console.error(err);
                     } else {
                       console.log('files moving out of', projectRoot, 'succeed');
+                    }
+                  }
+                );
+                var project_name_array = body.project_name.split(" / ");
+                var project_namespace = project_name_array[0];
+                var domainname = project_name_array[1];
+                console.log('setting up nginx + dnsmasq for ', domainname);
+                exec('$GITLAB_CE_PAGES_WEBHOOK_DIR/helper/generate_sites.sh ' + project_namespace + ' ' + domainname,
+                  (err, stdout, stderr) => {
+                    if (err) {
+                      console.error('generate_sites.sh helper', projectRoot, 'failed');
+                      console.error(err);
+                    } else {
+                      console.log('generate_sites.sh helper', projectRoot, 'succeed');
                     }
                   }
                 );
@@ -135,7 +149,7 @@ function update(body, pageDir) {
           console.error('mkdirp', tempDestination, 'to destination', destination, 'failed');
           console.error(err);
         }
-        extract(artifactName, artifactPath, tempDestination, pageDir);
+        extract(artifactName, artifactPath, tempDestination, pageDir, body);
       });
     });
     request

--- a/src/helper/generate_sites.sh
+++ b/src/helper/generate_sites.sh
@@ -41,6 +41,6 @@ _dnsmasq_config() {
 
 echo "cleaning sites config"
 find /etc/nginx/conf.d/ -type f -delete
-find /etc/dnsmasq.conf/ -type f -delete
+find /etc/dnsmasq.conf/ ! -name dnsmasq.conf -type f -delete
 _nginx_config "$1" "$2"
 [ ! -z $PUBLIC_IP ] && _dnsmasq_config "$2"

--- a/src/helper/generate_sites.sh
+++ b/src/helper/generate_sites.sh
@@ -1,19 +1,44 @@
 #/bin/bash
+
+_nginx_config() {
+  local line="$1"
+  echo "handling line: $line"
+  conf_name="${line//[^a-z0-9.]/-}.conf"
+  project_location=${line%% *}
+  server_names=${line#* }
+  echo "generating site config: $conf_name"
+  echo "server names(CNAME): $server_names"
+  echo "project location: $project_location"
+  project_location="${project_location/\//\\/}"
+  cp ${GITLAB_CE_PAGES_WEBHOOK_DIR}/helper/template.conf /tmp/$conf_name
+  /bin/sed -i "s/<server_names>/${server_names}/" /tmp/$conf_name
+  /bin/sed -i "s/<project_location>/$project_location/" /tmp/$conf_name
+  mv /tmp/$conf_name /etc/nginx/conf.d/
+}
+
+_dnsmasq_config() {
+  local line="$1"
+  conf_name="${line//[^a-z0-9.]/-}.conf"
+  gl_project=${line%% *}
+  gl_project=${gl_project/\//_}
+  gl_project_domains=${line#* }
+  gl_project_domains=${gl_project_domains/ /\/}
+  rm -f /etc/dnsmasq.d/"$gl_project".conf
+  echo "address=/$gl_project_domains/$PUBLIC_IP" >> /etc/dnsmasq.d/"$conf_name"
+  echo "local=/$gl_project_domains/" >> /etc/dnsmasq.d/"$conf_name"
+}
+
+_dnsmasq_restart() {
+  kill $(cat /var/run/dnsmasq/dnsmasq.pid) \
+  && /usr/sbin/dnsmasq -x /var/run/dnsmasq/dnsmasq.pid -u dnsmasq -7 /etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
+}
+
 echo "cleaning sites config"
-rm /etc/nginx/conf.d/*
+rm /etc/nginx/conf.d/* /etc/dnsmasq.conf/*
 echo "generating sites config for CNAME"
 while read -r line; do
-    echo "handling line: $line"
-    conf_name="${line//[^a-z0-9.]/-}.conf"
-    project_location=`expr "$line" : '\(\S\+\).*\$'`
-    server_names=`expr "$line" : '\S\+\s\+\(.*\)\$'`
-    echo "generating site config: $conf_name"
-    echo "server names(CNAME): $server_names"
-    echo "project location: $project_location"
-    project_location="${project_location/\//\\/}"
-    cp ${GITLAB_CE_PAGES_WEBHOOK_DIR}/helper/template.conf /tmp/$conf_name
-    /bin/sed -i "s/<server_names>/${server_names}/" /tmp/$conf_name
-    /bin/sed -i "s/<project_location>/$project_location/" /tmp/$conf_name
-    mv /tmp/$conf_name /etc/nginx/conf.d/
+  _nginx_config "$line"
+  [ ! -z $PUBLIC_IP ] && _dnsmasq_config "$line"
 done < ${GITLAB_CE_PAGES_CNAME_DIR}/cname.txt
 /usr/sbin/nginx -s reload
+[ ! -z $PUBLIC_IP ] && _dnsmasq_restart

--- a/src/helper/generate_sites.sh
+++ b/src/helper/generate_sites.sh
@@ -1,23 +1,28 @@
-#/bin/bash
+#!/bin/bash
 
 _nginx_config() {
-  local line="$1"
-  echo "handling line: $line"
-  conf_name="${line//[^a-z0-9.]/-}.conf"
-  project_location=${line%% *}
-  server_names=${line#* }
+  local project_location="$1"
+  local server_name="$2"
+  echo "generating dnsmasq config for $project_location/$server_name"
+  conf_name="$project_location.conf"
   echo "generating site config: $conf_name"
-  echo "server names(CNAME): $server_names"
+  echo "server names(CNAME): $server_name"
   echo "project location: $project_location"
-  project_location="${project_location/\//\\/}"
   cp ${GITLAB_CE_PAGES_WEBHOOK_DIR}/helper/template.conf /tmp/$conf_name
-  /bin/sed -i "s/<server_names>/${server_names}/" /tmp/$conf_name
-  /bin/sed -i "s/<project_location>/$project_location/" /tmp/$conf_name
+  /bin/sed -i "s/<server_names>/${server_name}/" /tmp/$conf_name
+  /bin/sed -i "s/<project_location>/$project_location\/$server_name/" /tmp/$conf_name
   mv /tmp/$conf_name /etc/nginx/conf.d/
+  /usr/sbin/nginx -s reload
+}
+
+_dnsmasq_restart() {
+  kill $(cat /var/run/dnsmasq/dnsmasq.pid) \
+  && /usr/sbin/dnsmasq -x /var/run/dnsmasq/dnsmasq.pid -u dnsmasq -7 /etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
 }
 
 _dnsmasq_config() {
   local line="$1"
+  echo "generating nginx sites config for $line"
   conf_name="${line//[^a-z0-9.]/-}.conf"
   gl_project=${line%% *}
   gl_project=${gl_project/\//_}
@@ -26,19 +31,16 @@ _dnsmasq_config() {
   rm -f /etc/dnsmasq.d/"$gl_project".conf
   echo "address=/$gl_project_domains/$PUBLIC_IP" >> /etc/dnsmasq.d/"$conf_name"
   echo "local=/$gl_project_domains/" >> /etc/dnsmasq.d/"$conf_name"
+  _dnsmasq_restart
 }
 
-_dnsmasq_restart() {
-  kill $(cat /var/run/dnsmasq/dnsmasq.pid) \
-  && /usr/sbin/dnsmasq -x /var/run/dnsmasq/dnsmasq.pid -u dnsmasq -7 /etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
-}
+##
+## $1 : project name
+## $2 : domain name
+##
 
 echo "cleaning sites config"
-rm /etc/nginx/conf.d/* /etc/dnsmasq.conf/*
-echo "generating sites config for CNAME"
-while read -r line; do
-  _nginx_config "$line"
-  [ ! -z $PUBLIC_IP ] && _dnsmasq_config "$line"
-done < ${GITLAB_CE_PAGES_CNAME_DIR}/cname.txt
-/usr/sbin/nginx -s reload
-[ ! -z $PUBLIC_IP ] && _dnsmasq_restart
+find /etc/nginx/conf.d/ -type f -delete
+find /etc/dnsmasq.conf/ -type f -delete
+_nginx_config "$1" "$2"
+[ ! -z $PUBLIC_IP ] && _dnsmasq_config "$2"

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-ce-pages",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Unofficial GitLab Pages for GitLab CE",
   "main": "index.js",
   "repository": "YuMS/gitlab-ce-pages",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-ce-pages",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Unofficial GitLab Pages for GitLab CE",
   "main": "index.js",
   "repository": "YuMS/gitlab-ce-pages",


### PR DESCRIPTION
We can use a simple DNS server (dnsmasq) to create a fake internal *.gitlab.io domain. Outside *.gitlab.io names will still work.

``` bash
$ cat /srv/gitlab-ce-pages/cname/cname.txt
morph027/foo foobar.gitlab.io
```

``` bash
$ nslookup pages.gitlab.io
Server:     my.internal.dns.server
Address:    my.internal.dns.server#53

Non-authoritative answer:
Name:   pages.gitlab.io
Address: 104.208.235.32

$ nslookup foobar.gitlab.io
Server:     my.internal.dns.server
Address:    my.internal.dns.server#53

Name:   foobar.gitlab.io
Address: gcp.server.ip.address
```

Looking forward to read your thoughts ;)
