### PR TITLE
Fixes #18 -- adding an error page directive for custom error pages

### DIFF
--- a/src/helper/template.conf
+++ b/src/helper/template.conf
@@ -2,4 +2,5 @@ server {
     listen 80;
     server_name <server_names>;
     root /home/pages/public/<project_location>;
+    error_page 404 = /404.html;
 }


### PR DESCRIPTION
Adds an error page directive to each vhost.  This allows custom 404 pages in the same way the official gitlab pages does: just add a 404.html to your project.    

If you don't add a 404.html to your project, the behaviour is the same as today: a generic nginx 404 page.

